### PR TITLE
fix compatibility with 2025.5

### DIFF
--- a/custom_components/custom_update_entities/__init__.py
+++ b/custom_components/custom_update_entities/__init__.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -50,5 +51,5 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Core Updater platform."""
     conf = config.get(DOMAIN, {})
-    hass.helpers.discovery.load_platform("update", DOMAIN, conf[CONF_UPDATERS], config)
+    load_platform(hass, "update", DOMAIN, conf[CONF_UPDATERS], config)
     return True

--- a/custom_components/custom_update_entities/update.py
+++ b/custom_components/custom_update_entities/update.py
@@ -79,7 +79,7 @@ class CustomUpdateEntity(UpdateEntity):
             self._attr_latest_version = state
         else:
             self._attr_installed_version = state
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()
  
     async def async_update(self):
         """Retrieve latest state."""


### PR DESCRIPTION
compatibility with 2025.5
fix for Error: 'HomeAssistant' object has no attribute 'helpers'
fix deprecation warning